### PR TITLE
crop image to remove title bar in OSX

### DIFF
--- a/image_diff.py
+++ b/image_diff.py
@@ -20,10 +20,7 @@ def calculate_image_difference(img1, img2):
     percent_diff = (num_diff_pixels / total_pixels) * 100
     return percent_diff
 
-def crop_img(img):
-    w,h = img.size
-    top_left = tuple((0, 0))
-    bottom_right = tuple((w, h//2))
+def crop_image(img, top_left, bottom_right):
 
     left = top_left[0]
     upper = top_left[1]

--- a/osx_screenshot.py
+++ b/osx_screenshot.py
@@ -10,6 +10,7 @@ import Quartz.CoreGraphics as CG
 import os
 import numpy as np
 from PIL import Image
+from image_diff import crop_image
 
 def cgimage_to_pil(cgimage):
     width = CGImageGetWidth(cgimage)
@@ -53,7 +54,7 @@ def find_window_id(window_name):
     return None
 
 
-def capture_window_to_pil(window_id, file_path):
+def capture_window_to_pil(window_id, file_path, crop_y_coordiante=37):
     #print(f"Capturing window {window_id}")
     #kCGWindowListOptionIncludingWindow
     image = CGWindowListCreateImage(CGRectNull, CG.kCGWindowListOptionIncludingWindow, window_id, 0)
@@ -70,14 +71,20 @@ def capture_window_to_pil(window_id, file_path):
         if pil_image.mode == 'RGBA':
             pil_image = pil_image.convert('RGB')
 
+        # crop the title bar
+        w,h = pil_image.size
+        top_left = tuple((0, crop_y_coordiante))
+        bottom_right = tuple((w, h))
+        pil_image = crop_image(pil_image, top_left, bottom_right)
+
         return pil_image         
     else:
         print("Failed to capture window.")
         return None
 
-def capture_window_to_file(window_id, file_path):
+def capture_window_to_file(window_id, file_path, crop_y_coordiante=37):
     print(f"Capturing window {window_id} to {file_path}")
-    pil_image = capture_window_to_pil(window_id, file_path)
+    pil_image = capture_window_to_pil(window_id, file_path, crop_y_coordiante)
     if pil_image != None:
         print(f"Saved window capture to {file_path}")
         pil_image.save('output.jpg')

--- a/process_frames.py
+++ b/process_frames.py
@@ -373,7 +373,11 @@ class FrameProcessor:
             # print("Images are more than 10% different. Proceed with OCR.")
             print("Images are more than 7 hamming distance. Proceed with OCR")
 
-            img_crop = crop_img(img)
+            # crop the image to top half
+            w,h = img.size
+            top_left = tuple((0, 0))
+            bottom_right = tuple((w, h//2))
+            img_crop = crop_img(img, top_left, bottom_right)
 
             # cache
             then = time.time()


### PR DESCRIPTION
modified crop_image function in image_diff.py to take top_left and bottom_right args.

Used crop_image function on osx_screenshot.py to crop the title bar, default 37 top y coordinate.

![title_bar_cropped](https://github.com/VoxlyHq/retro_voice/assets/26071811/e5536bec-ea00-47a4-8b3c-f54afcc3a573)