### PR TITLE
FAST text detector fine-tuned for final fantasy 2 EN and 4 JP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv*/
 eval_data
 static/app/
 html/.vite
+visualize

--- a/test_detector_configs/fast_tiny.config
+++ b/test_detector_configs/fast_tiny.config
@@ -1,0 +1,231 @@
+{
+    "name": "ProxylessNASNets",
+    "bn": {
+        "momentum": 0.1,
+        "eps": 0.001
+    },
+    "first_conv": {
+        "name": "ConvLayer",
+        "kernel_size": 3,
+        "stride": 2,
+        "dilation": 1,
+        "groups": 1,
+        "bias": false,
+        "has_shuffle": false,
+        "in_channels": 3,
+        "out_channels": 64,
+        "use_bn": true,
+        "act_func": "relu",
+        "dropout_rate": 0,
+        "ops_order": "weight_bn_act"
+    },
+    "stage1": [
+        {
+            "name": "RepConvLayer",
+            "in_channels": 64,
+            "out_channels": 64,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 64,
+            "out_channels": 64,
+            "kernel_size": [3, 3],
+            "stride": 2,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 64,
+            "out_channels": 64,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        }
+    ],
+    "stage2": [
+        {
+            "name": "RepConvLayer",
+            "in_channels": 64,
+            "out_channels": 128,
+            "kernel_size": [3, 3],
+            "stride": 2,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 128,
+            "out_channels": 128,
+            "kernel_size": [1, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 128,
+            "out_channels": 128,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 128,
+            "out_channels": 128,
+            "kernel_size": [3, 1],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        }
+    ],
+    "stage3": [
+        {
+            "name": "RepConvLayer",
+            "in_channels": 128,
+            "out_channels": 256,
+            "kernel_size": [3, 3],
+            "stride": 2,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 256,
+            "out_channels": 256,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 256,
+            "out_channels": 256,
+            "kernel_size": [3, 1],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 256,
+            "out_channels": 256,
+            "kernel_size": [1, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        }
+    ],
+    "stage4": [
+        {
+            "name": "RepConvLayer",
+            "in_channels": 256,
+            "out_channels": 512,
+            "kernel_size": [3, 3],
+            "stride": 2,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 512,
+            "out_channels": 512,
+            "kernel_size": [3, 1],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 512,
+            "out_channels": 512,
+            "kernel_size": [1, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        {
+            "name": "RepConvLayer",
+            "in_channels": 512,
+            "out_channels": 512,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        }
+    ],
+    "head": {
+        "name": "Head",
+        "conv": {
+            "name": "RepConvLayer",
+            "in_channels": 512,
+            "out_channels": 128,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        "final": {
+            "name": "ConvLayer",
+            "kernel_size": 1,
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1,
+            "bias": false,
+            "has_shuffle": false,
+            "in_channels": 128,
+            "out_channels": 5,
+            "use_bn": false,
+            "act_func": null,
+            "dropout_rate": 0,
+            "ops_order": "weight"
+        }
+    },
+    "neck": {
+        "name": "Neck",
+        "reduce_layer1": {
+            "name": "RepConvLayer",
+            "in_channels": 64,
+            "out_channels": 128,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        "reduce_layer2": {
+            "name": "RepConvLayer",
+            "in_channels": 128,
+            "out_channels": 128,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        "reduce_layer3": {
+            "name": "RepConvLayer",
+            "in_channels": 256,
+            "out_channels": 128,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        },
+        "reduce_layer4": {
+            "name": "RepConvLayer",
+            "in_channels": 512,
+            "out_channels": 128,
+            "kernel_size": [3, 3],
+            "stride": 1,
+            "dilation": 1,
+            "groups": 1
+        }
+    }
+}

--- a/test_detector_configs/fast_tiny_ic15_736_finetune_ic17mlt.py
+++ b/test_detector_configs/fast_tiny_ic15_736_finetune_ic17mlt.py
@@ -1,0 +1,66 @@
+model = dict(
+    type='FAST',
+    backbone=dict(
+        type='fast_backbone',
+        config='test_detector_configs/fast_tiny.config'
+    ),
+    neck=dict(
+        type='fast_neck',
+        config='test_detector_configs/fast_tiny.config'
+    ),
+    detection_head=dict(
+        type='fast_head',
+        config='test_detector_configs/fast_tiny.config',
+        pooling_size=9,
+        dropout_ratio=0.1,
+        loss_text=dict(
+            type='DiceLoss',
+            loss_weight=0.5
+        ),
+        loss_kernel=dict(
+            type='DiceLoss',
+            loss_weight=1.0
+        ),
+        loss_emb=dict(
+            type='EmbLoss_v1',
+            feature_dim=4,
+            loss_weight=0.25
+        )
+    )
+)
+repeat_times = 10
+data = dict(
+    batch_size=4,
+    train=dict(
+        type='FAST_IC15',
+        split='train',
+        is_transform=True,
+        img_size=736,
+        short_size=736,
+        pooling_size=9,
+        read_type='cv2',
+        repeat_times=repeat_times
+    ),
+    test=dict(
+        type='FAST_IC15',
+        split='test',
+        short_size=736,
+        read_type='cv2'
+    )
+)
+train_cfg = dict(
+    lr=1e-3,
+    schedule='polylr',
+    epoch=600 // repeat_times,
+    optimizer='Adam',
+    #pretrain='pretrained/fast_tiny_ic17mlt_640.pth',
+    pretrain='pretrained/fast_tiny_ic15_736_finetune_ic17mlt.pth',
+    # https://github.com/czczup/FAST/releases/download/release/fast_tiny_ic17mlt_640.pth
+    save_interval=10 // repeat_times,
+)
+test_cfg = dict(
+    min_score=0.88,
+    min_area=250,
+    bbox_type='rect',
+    result_path='outputs/submit_ic15.zip'
+)

--- a/text_detector_fast.py
+++ b/text_detector_fast.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 import fast
 
 class TextDetectorFast:
-    def __init__(self, model_path, min_confidence=0.5, width=240, height=240, padding=0.0, checkpoint="checkpoints/checkpoint_31ep.pth.tar"):
+    def __init__(self, model_path, min_confidence=0.5, width=240, height=240, padding=0.0, checkpoint="checkpoints/checkpoint_60ep.pth.tar"):
         self.model_path = model_path
         self.min_confidence = min_confidence
         self.width = width
@@ -69,6 +69,7 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("-i", "--image_dir", type=str, default='eval_data/images', help="paths to input images")
     ap.add_argument("-m", "--pretrained_model", type=str, default="pretrained/fast_tiny_ic15_736_finetune_ic17mlt.pth", help="path to input pretrained model")
+    ap.add_argument("-cp", "--checkpoint", type=str, default="checkpoints/checkpoint_60ep.pth.tar", help="path to checkpoint model")
     ap.add_argument("-c", "--min-confidence", type=float, default=0.5, help="minimum probability required to inspect a region")
     ap.add_argument("-w", "--width", type=int, default=320, help="nearest multiple of 32 for resized width")
     ap.add_argument("-e", "--height", type=int, default=320, help="nearest multiple of 32 for resized height")
@@ -79,7 +80,9 @@ if __name__ == "__main__":
     total_duration = 0
 
     pretrained_model = args["pretrained_model"]
-    assert Path(pretrained_model).exists(), 'Please download the pretrained model from here. [https://github.com/czczup/FAST/blob/main/config/fast/ic15/fast_tiny_ic15_736_finetune_ic17mlt.py]'
+    checkpoint_model = args["checkpoint"]
+    assert Path(pretrained_model).exists(), 'Please download the pretrained model from here. [https://github.com/czczup/FAST/releases/download/release/fast_tiny_ic15_736_finetune_ic17mlt.pth]'
+    assert Path(checkpoint_model).exists(), 'Please download the checkpoint model from here. [https://drive.google.com/file/d/18J2h1TBqqgli7QkH2ccmKq58IMpYSFHR/view?usp=drive_link]'
 
     image_dir = Path(args["image_dir"])
     image_paths = [i for i in image_dir.iterdir() if i.is_file() and i.suffix == '.jpg']
@@ -89,7 +92,7 @@ if __name__ == "__main__":
     
     abs_start_time = time.time()
 
-    detector = TextDetectorFast(pretrained_model, args["min_confidence"], args["width"], args["height"], args["padding"])
+    detector = TextDetectorFast(pretrained_model, args["min_confidence"], args["width"], args["height"], args["padding"], checkpoint=checkpoint_model)
 
     for image_path in tqdm(image_paths):
         image = Image.open(image_path)

--- a/text_detector_fast.py
+++ b/text_detector_fast.py
@@ -4,11 +4,14 @@ import time
 import os
 
 
-from PIL import Image
+from PIL import Image, ImageDraw
+from pathlib import Path
+from tqdm import tqdm
+
 import fast
 
 class TextDetectorFast:
-    def __init__(self, model_path, min_confidence=0.5, width=320, height=320, padding=0.0, checkpoint=None):
+    def __init__(self, model_path, min_confidence=0.5, width=240, height=240, padding=0.0, checkpoint="checkpoints/checkpoint_31ep.pth.tar"):
         self.model_path = model_path
         self.min_confidence = min_confidence
         self.width = width
@@ -16,8 +19,8 @@ class TextDetectorFast:
         self.padding = padding
 
         self.graph = self.load_model()
-        # self.fast = fast.FAST(config="test_detector_configs/fast_tiny_ic17mlt_640.py", checkpoint=checkpoint,ema=True)
-        self.fast = fast.FAST(config="test_detector_configs/tt_fast_base_tt_640_finetune_ic17mlt.py", checkpoint=checkpoint,ema=True)
+        self.fast = fast.FAST(config="test_detector_configs/fast_tiny_ic15_736_finetune_ic17mlt.py", checkpoint=checkpoint,ema=True)
+        # self.fast = fast.FAST(config="test_detector_configs/tt_fast_base_tt_640_finetune_ic17mlt.py", checkpoint=checkpoint,ema=True)
 
     def load_image(self, image_path):
         image = Image.open(image_path).convert('RGB')
@@ -52,35 +55,63 @@ class TextDetectorFast:
     def close_session(self):
         None
 
+def convert_to_top_left_bottom_right(coordinate_sets):
+    converted_sets = []
+    for coords in coordinate_sets:
+        x_coords = coords[0::2]
+        y_coords = coords[1::2]
+        top_left = (min(x_coords), min(y_coords))
+        bottom_right = (max(x_coords), max(y_coords))
+        converted_sets.append((top_left, bottom_right))
+    return converted_sets
+
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
-    ap.add_argument("-i", "--images", type=str, nargs='+', required=True, help="paths to input images")
-    ap.add_argument("-east", "--east", type=str, required=True, help="path to input EAST text detector")
+    ap.add_argument("-i", "--image_dir", type=str, default='eval_data/images', help="paths to input images")
+    ap.add_argument("-m", "--pretrained_model", type=str, default="pretrained/fast_tiny_ic15_736_finetune_ic17mlt.pth", help="path to input pretrained model")
     ap.add_argument("-c", "--min-confidence", type=float, default=0.5, help="minimum probability required to inspect a region")
     ap.add_argument("-w", "--width", type=int, default=320, help="nearest multiple of 32 for resized width")
     ap.add_argument("-e", "--height", type=int, default=320, help="nearest multiple of 32 for resized height")
     ap.add_argument("-p", "--padding", type=float, default=0.0, help="amount of padding to add to each border of ROI")
     args = vars(ap.parse_args())
 
-    # total_duration = 0
-    # image_path = args["images"][0]
+
+    total_duration = 0
+
+    pretrained_model = args["pretrained_model"]
+    assert Path(pretrained_model).exists(), 'Please download the pretrained model from here. [https://github.com/czczup/FAST/blob/main/config/fast/ic15/fast_tiny_ic15_736_finetune_ic17mlt.py]'
+
+    image_dir = Path(args["image_dir"])
+    image_paths = [i for i in image_dir.iterdir() if i.is_file() and i.suffix == '.jpg']
+
+    output_dir = Path('visualize')
+    output_dir.mkdir(exist_ok=True)
     
-    # abs_start_time = time.time()
+    abs_start_time = time.time()
 
-    # detector = TextDetector(args["east"], args["min_confidence"], args["width"], args["height"], args["padding"])
-    # image, orig, rW, rH, origW, origH = detector.get_image_attrs(Image.open(image_path))
-    # for i in range(100):
-    #     start_time = time.time()
-    #     results = detector.has_text(image)
-    #     # print(f"Results for {image_path}:")
+    detector = TextDetectorFast(pretrained_model, args["min_confidence"], args["width"], args["height"], args["padding"])
+
+    for image_path in tqdm(image_paths):
+        image = Image.open(image_path)
+        start_time = time.time()
+        results = detector.process_single_image(image)
+        end_time = time.time()
+        total_duration += end_time - start_time
+
+        converted_coordinates = convert_to_top_left_bottom_right(results)
         
-    #     # print(results)
-    #     end_time = time.time()
-    #     total_duration += end_time - start_time
+        draw = ImageDraw.Draw(image)
 
-    # detector.close_session()
-    # average_duration = total_duration / 100
-    # print(f"Average duration: {average_duration:.4f} seconds")
-    # print(f"Total duration: {total_duration:.4f} seconds")
-    # fps = 100 / (time.time() - abs_start_time)
-    # print(f"FPS: {fps:.2f}")
+        for xy in converted_coordinates:
+            draw.rectangle(xy)
+        output = output_dir.joinpath(image_path.stem + '_visualize' + image_path.suffix)
+        image.save(output)
+
+    print(f"Output images are saved in {output_dir}")
+    detector.close_session()
+
+    average_duration = total_duration / 100
+    print(f"Average duration: {average_duration:.4f} seconds")
+    print(f"Total duration: {total_duration:.4f} seconds")
+    fps = len(image_paths) / (time.time() - abs_start_time)
+    print(f"FPS: {fps:.2f}")


### PR DESCRIPTION
A FAST model (fast_tiny_ic15_736_finetune_ic17mlt) is fine-tuned on total **170** _FF2_EN_ and _FF4_JP_ images. 
The model is clearly overfitting which means that It won't be generalize well to other types of images.
But that also means that it works really well on the trained data.

- download [pretrained_model ](https://github.com/czczup/FAST/releases/download/release/fast_tiny_ic15_736_finetune_ic17mlt.pth) and put it in **pretrained/** folder.
- download [checkpoints model](https://drive.google.com/file/d/18J2h1TBqqgli7QkH2ccmKq58IMpYSFHR/view?usp=drive_link) and put it in **checkpoints/** folder.
```
python text_detector_fast.py
```
The annotated output images can be seen in **visualize/** folder. 