### PR TITLE
Speed up `print_annotations` 

### DIFF
--- a/server/stream_http_video.py
+++ b/server/stream_http_video.py
@@ -374,9 +374,9 @@ async def handle_offer(params):
                 disable_translation = True
             print(f"disable_translation = {disable_translation}")
 
-            method = OCREngine.CLAUDE
+            method = OCREngine.EASYOCR
             detection_method = DETEngine.FAST
-            translation_method = TranslationEngine.CLAUDE
+            translation_method = TranslationEngine.OPENAI
             
 
             with sentry_sdk.start_transaction(op="task", name="Start Video stream"):

--- a/tests/test_frameprocessor.py
+++ b/tests/test_frameprocessor.py
@@ -40,7 +40,7 @@ class TestFrameProcessor(unittest.TestCase):
     
     def test_save_outputs(self):
         # Run the image through the processor
-        last_played, previous_image, highlighted_image, annotations, translation = self.processor.run_image(self.input_image)
+        last_played, previous_image, highlighted_image, annotations, translation,background_image = self.processor.run_image(self.input_image)
         
         # # Save the outputs to disk
         # self.processor.save_outputs_to_disk(self.input_image, highlighted_image, annotations, translation)


### PR DESCRIPTION
### Move `_generate_blurred_image` method from `VideoStreamWithAnnotations` to `FrameProcessor`.

Before this change, the function is being used during `print_annotations` and being to applied to **every frame** and it is the **longest** in `print_annotations`.

| Methods in `print_annotations`                       | Time                                                                         |
| ---------------------------- | ---------------------------------------------------------------------------- |
| **_generate_blurred_image**  | **11.8 ms** ± 150 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   |
| _calculate_annotation_bounds | 257 ns ± 2.93 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each) |
| calculate_font_size          | 2.85 ms ± 45.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)      |
| adjust_translation_text      | 32.4 µs ± 321 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)    |
| _annotate_translation        | 143 µs ± 632 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)     |

Since `_generate_blurred_image` is moved to `FrameProcessor`, It only needs to run only on different frames with dialogue. 

| print_annotations                       | Time                                                                    |
| --------------------------------------- | ----------------------------------------------------------------------- |
| Before moving `_generate_blurred_image` | 15.3 ms ± 97.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) |
| After moving `_generate_blurred_image`  | 3.45 ms ± 19.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) |

### Convert `_gradient_blurred_image` code from PIL to opencv,

|          | Time                                                                    |
| -------- | ----------------------------------------------------------------------- |
| PIL code | 11.9 ms ± 224 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  |
| cv2 code | 6.68 ms ± 78.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) |
